### PR TITLE
ci: add GitHub Actions workflow for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - release/**
+      - stable
+  pull_request:
+    branches:
+      - main
+      - release/**
+      - codex/**
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        std: [11, 17]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install compiler (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: choco install mingw -y --no-progress
+      - name: Build and test
+        shell: bash
+        run: |
+          EXE=""
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then EXE=".exe"; fi
+          g++ -std=c++${{ matrix.std }} -O3 tests/test_kat.cpp tests/rfc8032_vectors.cpp -o test_kat
+          ./test_kat$EXE
+          g++ -std=c++${{ matrix.std }} -O3 tests/test_sign_verify.cpp tests/rfc8032_vectors.cpp -o test_sign_verify
+          ./test_sign_verify$EXE


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to compile and run tests on Linux and Windows for C++11 and C++17

## Testing
- `g++ -std=c++11 -O3 tests/test_kat.cpp tests/rfc8032_vectors.cpp -o test_kat && ./test_kat`
- `g++ -std=c++11 -O3 tests/test_sign_verify.cpp tests/rfc8032_vectors.cpp -o test_sign_verify && ./test_sign_verify`


------
https://chatgpt.com/codex/tasks/task_e_68bfa01143f8832ca2582b457c7090ac