### PR TITLE
feat(mql5): add shim and refactor portable core

### DIFF
--- a/ed25519_mql5.mqh
+++ b/ed25519_mql5.mqh
@@ -1,0 +1,53 @@
+#pragma once
+#property strict
+
+typedef uchar u8;
+typedef uint  u32;
+typedef ulong u64;
+typedef int   i32;
+typedef long  i64;
+typedef int   ed_size;
+
+#ifndef ED_INLINE
+#define ED_INLINE static
+#endif
+
+#include "portable/ed25519_portable.inl"
+
+/// \brief Generate Ed25519 keypair from seed.
+/// @param sk Secret key output (32 bytes).
+/// @param pk Public key output (32 bytes).
+/// @param seed Input seed (32 bytes).
+/// @return true on success, false on size mismatch.
+bool ed25519_keypair_from_seed_mql(uchar &sk[], uchar &pk[], const uchar &seed[]) {
+  if(ArraySize(sk) < 32 || ArraySize(pk) < 32 || ArraySize(seed) < 32)
+    return false;
+  return ed25519_keypair_from_seed(sk, pk, seed) == 1;
+}
+
+/// \brief Sign message with Ed25519.
+/// @param msg Message bytes.
+/// @param msg_len Message length.
+/// @param sk Secret key (32 bytes).
+/// @param pk Public key (32 bytes).
+/// @param sig Signature output (64 bytes).
+/// @return true on success, false on size mismatch.
+bool ed25519_sign_mql(const uchar &msg[], int msg_len,
+                      const uchar &sk[], const uchar &pk[], uchar &sig[]) {
+  if(ArraySize(sk) < 32 || ArraySize(pk) < 32 || ArraySize(sig) < 64)
+    return false;
+  return ed25519_sign(msg, (ed_size)msg_len, sk, pk, sig) == 1;
+}
+
+/// \brief Verify Ed25519 signature.
+/// @param msg Message bytes.
+/// @param msg_len Message length.
+/// @param pk Public key (32 bytes).
+/// @param sig Signature (64 bytes).
+/// @return true if signature is valid and sizes are OK.
+bool ed25519_verify_mql(const uchar &msg[], int msg_len,
+                        const uchar &pk[], const uchar &sig[]) {
+  if(ArraySize(pk) < 32 || ArraySize(sig) < 64)
+    return false;
+  return ed25519_verify(msg, (ed_size)msg_len, pk, sig) == 1;
+}

--- a/include/ed25519_cpp11.hpp
+++ b/include/ed25519_cpp11.hpp
@@ -1,11 +1,27 @@
 #pragma once
 #include <cstdint>
-typedef uint8_t  u8; typedef uint32_t u32; typedef uint64_t u64;
+
+typedef uint8_t  u8;
+typedef uint32_t u32;
+typedef uint64_t u64;
+typedef int      i32;
+typedef long long i64;
+typedef int      ed_size;
+
+#ifndef ED_INLINE
 #define ED_INLINE inline
+#endif
+
 #include "../portable/ed25519_portable.inl"
 
 namespace ed25519 {
-inline bool keypair_from_seed(u8 sk[32], u8 pk[32], const u8 seed[32]) { return ed25519_keypair_from_seed(sk, pk, seed) == 1; }
-inline bool sign(const u8* m, int n, const u8 sk[32], const u8 pk[32], u8 sig[64]) { return ed25519_sign(m, n, sk, pk, sig) == 1; }
-inline bool verify(const u8* m, int n, const u8 pk[32], const u8 sig[64]) { return ed25519_verify(m, n, pk, sig) == 1; }
+inline bool keypair_from_seed(u8 sk[32], u8 pk[32], const u8 seed[32]) {
+  return ed25519_keypair_from_seed(sk, pk, seed) == 1;
+}
+inline bool sign(const u8* m, ed_size n, const u8 sk[32], const u8 pk[32], u8 sig[64]) {
+  return ed25519_sign(m, n, sk, pk, sig) == 1;
+}
+inline bool verify(const u8* m, ed_size n, const u8 pk[32], const u8 sig[64]) {
+  return ed25519_verify(m, n, pk, sig) == 1;
+}
 }


### PR DESCRIPTION
## Summary
- refactor portable core to drop standard headers and use shim-defined types
- update C++ wrapper for new typedefs
- add MQL5 shim with safe array-size checks

## Testing
- `g++ -std=c++11 -O3 tests/test_kat.cpp tests/rfc8032_vectors.cpp -o test_kat && ./test_kat`
- `g++ -std=c++11 -O3 tests/test_sign_verify.cpp -o test_sign_verify && ./test_sign_verify`


------
https://chatgpt.com/codex/tasks/task_e_68bfae1deebc832ca35e41129d403c22